### PR TITLE
Update GitHub token

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Create pull request
         run: gh pr create -B main -H metadata-update-${{ steps.date.outputs.date }} --title 'Merge metadata-update-${{ steps.date.outputs.date }} into main' --body 'Automatic sync PR to update reference files from contrib'
         env:
-          GITHUB_TOKEN: ${{ secrets.PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change on its own might get the GitHub action working again. If not, follow this step:

Go to Settings -> Actions -> General -> Workflow permissions and check Allow GitHub Actions to create and approve pull requests