### PR TITLE
Update splunk_hec.yaml 

### DIFF
--- a/cfg-metadata/exporter/splunk_hec.yaml
+++ b/cfg-metadata/exporter/splunk_hec.yaml
@@ -313,7 +313,7 @@ fields:
   default: ""
   doc: |
     App version is used to track telemetry information for Splunk App's using HEC by App version. Defaults to the current OpenTelemetry Collector Contrib build version.
-- name: hec_metadata_to_otel_attrs
+- name: otel_attrs_to_hec_metadata
   type: splunk.HecToOtelAttrs
   kind: struct
   doc: |


### PR DESCRIPTION
Based on the changes made in this merge https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35476/changes, `otel_attrs_to_hec_metadata/*` config fields replaces the `hec_metadata_to_otel_attrs/*`